### PR TITLE
Remove `.whitesource`

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,3 +1,0 @@
-{
-  "settingsInheritedFrom": "ibm-q-research/whitesource-config@main"
-}


### PR DESCRIPTION
This was just an artifact of this package's legacy in IBM inner source.